### PR TITLE
It's just "Clarissa"

### DIFF
--- a/images/cover.svg
+++ b/images/cover.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="0 0 1400 2100">
-	<title>The cover for the Standard Ebooks edition of Clarissa Harlowe, by Samuel Richardson</title>
+	<title>The cover for the Standard Ebooks edition of Clarissa, by Samuel Richardson</title>
 	<style type="text/css">
 		.title-box{
 			fill-opacity: .75;
@@ -23,7 +23,6 @@
 	</style>
 	<image height="2100" width="1400" x="0" y="0" xlink:href="cover.jpg"/>
 	<path class="title-box" d="M 50,1620 1350,1620 1350,2050 50,2050 Z"/>
-	<text class="title" x="700" y="1775">CLARISSA</text>
-	<text class="title" x="700" y="1875">HARLOWE</text>
-	<text class="author" x="700" y="1975">SAMUEL RICHARDSON</text>
+	<text class="title" x="700" y="1825">CLARISSA</text>
+	<text class="author" x="700" y="1925">SAMUEL RICHARDSON</text>
 </svg>

--- a/images/titlepage.svg
+++ b/images/titlepage.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 1400 340">
-	<title>The titlepage for the Standard Ebooks edition of Clarissa Harlowe, by Samuel Richardson</title>
+	<title>The titlepage for the Standard Ebooks edition of Clarissa, by Samuel Richardson</title>
 	<style type="text/css">
 		text{
 			font-family: "League Spartan";
@@ -16,6 +16,6 @@
 			font-size: 70.17543793px;
 		}
 	</style>
-	<text class="title" x="700" y="130">CLARISSA HARLOWE</text>
+	<text class="title" x="700" y="130">CLARISSA</text>
 	<text class="author" x="700" y="290">SAMUEL RICHARDSON</text>
 </svg>

--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -26,14 +26,14 @@
 		<meta property="schema:accessibilityHazard">none</meta>
 		<meta property="schema:accessibilitySummary">This publication conforms to WCAG 2.1 Level AA.</meta>
 		<link href="onix.xml" media-type="application/xml" properties="onix" rel="record"/>
-		<dc:title id="title">Clarissa Harlowe</dc:title>
-		<meta property="file-as" refines="#title">Clarissa Harlowe</meta>
+		<dc:title id="title">Clarissa</dc:title>
+		<meta property="file-as" refines="#title">Clarissa</meta>
 		<meta property="title-type" refines="#title">main</meta>
 		<dc:title id="subtitle">Or, the History of a Young Lady</dc:title>
 		<meta property="file-as" refines="#subtitle">Or, the History of a Young Lady</meta>
 		<meta property="title-type" refines="#subtitle">subtitle</meta>
-		<dc:title id="fulltitle">Clarissa Harlowe, or the History of a Young Lady</dc:title>
-		<meta property="file-as" refines="#fulltitle">Clarissa Harlowe</meta>
+		<dc:title id="fulltitle">Clarissa, or the History of a Young Lady</dc:title>
+		<meta property="file-as" refines="#fulltitle">Clarissa</meta>
 		<meta property="title-type" refines="#fulltitle">extended</meta>
 		<dc:subject id="subject-1">England -- Fiction</dc:subject>
 		<dc:subject id="subject-2">Psychological fiction</dc:subject>
@@ -68,7 +68,7 @@
 		<meta property="group-position" refines="#collection-3">6</meta>
 		<dc:description id="description">A beautiful and virtuous young lady is entangled in the snares of a handsome but unscrupulous rake.</dc:description>
 		<meta id="long-description" property="se:long-description" refines="#description">
-			&lt;p&gt;&lt;i&gt;Clarissa Harlowe, or The History of a Young Lady&lt;/i&gt; is one of the longest novels in the English language. Written by &lt;a href="https://standardebooks.org/ebooks/samuel-richardson"&gt;Samuel Richardson&lt;/a&gt; over a period of several years and published in 1748, it is composed entirely of letters. Though this may seem daunting, the novel is highly regarded and is considered by many critics as one of the greatest works of English literature, appearing in several lists of the best British novels ever written.&lt;/p&gt;
+			&lt;p&gt;&lt;i&gt;Clarissa, or The History of a Young Lady&lt;/i&gt; is one of the longest novels in the English language. Written by &lt;a href="https://standardebooks.org/ebooks/samuel-richardson"&gt;Samuel Richardson&lt;/a&gt; over a period of several years and published in 1748, it is composed entirely of letters. Though this may seem daunting, the novel is highly regarded and is considered by many critics as one of the greatest works of English literature, appearing in several lists of the best British novels ever written.&lt;/p&gt;
 			&lt;p&gt;The novel tells the story of young Clarissa, eighteen years of age at the start of the novel. She is generally regarded by her family, neighbors, and friends as the most virtuous and kind young woman they know. But she is drawn into correspondence with Richard Lovelace, a well-born, rich young man regarded as something of a rake, when she attempts to reconcile a dispute between Lovelace and her rash brother. Lovelace, imagining this indicates her love for him, carries out a series of strategems which result in him essentially abducting her from her family, from whom Clarissa then becomes estranged.&lt;/p&gt;
 			&lt;p&gt;Much of the correspondence consists of the letters between Clarissa and her close friend Anna Howe, and between Lovelace and his friend Jack Belford, to whom he confesses all of his strategems and “inventions” in his assault on Clarissa’s honor.&lt;/p&gt;
 			&lt;p&gt;The novel is thus a fascinating study of human nature. Much of Lovelace’s actions and attitudes towards women are regrettably only too familiar to modern readers. And while Clarissa herself may be a little too good to be true, nevertheless she is shown as having some flaws which lead to a tragic outcome.&lt;/p&gt;

--- a/src/epub/text/colophon.xhtml
+++ b/src/epub/text/colophon.xhtml
@@ -11,7 +11,7 @@
 				<h2 epub:type="title">Colophon</h2>
 				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="z3998:publisher-logo se:image.color-depth.black-on-transparent"/>
 			</header>
-			<p><i epub:type="se:name.publication.book">Clarissa Harlowe</i><br/>
+			<p><i epub:type="se:name.publication.book">Clarissa</i><br/>
 			was published in 1748 by<br/>
 			<a href="https://en.wikipedia.org/wiki/Samuel_Richardson">Samuel Richardson</a>.</p>
 			<p>This ebook was produced for<br/>

--- a/src/epub/text/halftitlepage.xhtml
+++ b/src/epub/text/halftitlepage.xhtml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/, se: https://standardebooks.org/vocab/1.0" xml:lang="en-GB">
 	<head>
-		<title>Clarissa Harlowe</title>
+		<title>Clarissa</title>
 		<link href="../css/core.css" rel="stylesheet" type="text/css"/>
 		<link href="../css/se.css" rel="stylesheet" type="text/css"/>
 		<link href="../css/local.css" rel="stylesheet" type="text/css"/>
@@ -9,7 +9,7 @@
 	<body epub:type="frontmatter">
 		<section id="halftitlepage" epub:type="halftitlepage">
 			<hgroup epub:type="fulltitle">
-				<h2 epub:type="title">Clarissa Harlowe</h2>
+				<h2 epub:type="title">Clarissa</h2>
 				<p epub:type="subtitle">Or, The History of a Young Lady</p>
 			</hgroup>
 		</section>

--- a/src/epub/text/titlepage.xhtml
+++ b/src/epub/text/titlepage.xhtml
@@ -7,7 +7,7 @@
 	</head>
 	<body epub:type="frontmatter">
 		<section id="titlepage" epub:type="titlepage">
-			<h1 epub:type="title">Clarissa Harlowe</h1>
+			<h1 epub:type="title">Clarissa</h1>
 			<p>By <b epub:type="z3998:personal-name z3998:author">Samuel Richardson</b>.</p>
 			<img alt="" src="../images/titlepage.svg" epub:type="se:image.color-depth.black-on-transparent"/>
 		</section>

--- a/src/epub/toc.xhtml
+++ b/src/epub/toc.xhtml
@@ -17,7 +17,7 @@
 					<a href="text/preface.xhtml">Preface</a>
 				</li>
 				<li>
-					<a href="text/halftitlepage.xhtml">Clarissa Harlowe</a>
+					<a href="text/halftitlepage.xhtml">Clarissa</a>
 					<ol>
 						<li>
 							<a href="text/letter-1.xhtml">Letter 1: Miss Anna Howe, to Miss Clarissa Harlowe</a>
@@ -1658,7 +1658,7 @@
 			<h2 epub:type="title">Landmarks</h2>
 			<ol>
 				<li>
-					<a href="text/letter-1.xhtml" epub:type="bodymatter">Clarissa Harlowe</a>
+					<a href="text/letter-1.xhtml" epub:type="bodymatter">Clarissa</a>
 				</li>
 				<li>
 					<a href="text/endnotes.xhtml" epub:type="backmatter endnotes">Endnotes</a>


### PR DESCRIPTION
Standard Ebooks is the first time I've seen this novel referred to as "Clarissa Harlowe". It should just be "Clarissa". That's how it's named on the lists it appears on (as linked to on https://standardebooks.org/ebooks/samuel-richardson/clarissa-harlowe):

https://www.theguardian.com/books/2015/aug/17/the-100-best-novels-written-in-english-the-full-list

https://www.bbc.com/culture/article/20151204-the-100-greatest-british-novels

https://www.telegraph.co.uk/culture/books/3560987/50-greatest-villains-in-literature.html%20

Wikipedia also has an image of the title page from what looks like the original M.DCC.XLVIII printing that also lists the name as "CLARISSA. OR, [etc.]" https://en.wikipedia.org/wiki/Clarissa

You will need to regenerate src/epub/images